### PR TITLE
Walk dependency tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,5 @@ Usage
 apply plugin: 'aar-link-sources'
 ~~~
 
-Tips
-----
-If you want to see the debug log, just add this line in your build script.
-~~~groovy
-rootProject.aarLinkSources.debug = true
-~~~
-
-Output:
-~~~
-[AARLinkSources] [Info] Link sources: support-v4-21.0.3-sources.jar
-[AARLinkSources] [Info] Link success: support_v4_21_0_3.xml
-~~~
-
-
 
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@ Usage
 ----
 ~~~groovy
 apply plugin: 'aar-link-sources'
-
-dependencies {
-    compile 'com.android.support:support-v4:21.0.3'
-    aarLinkSources 'com.android.support:support-v4:21.0.3:sources@jar'
-}
 ~~~
 
 Tips

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip

--- a/plugin/src/main/groovy/com/xujiaao/android/idea/AARLinkSourcesPlugin.groovy
+++ b/plugin/src/main/groovy/com/xujiaao/android/idea/AARLinkSourcesPlugin.groovy
@@ -18,31 +18,41 @@ package com.xujiaao.android.idea
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.jvm.JvmLibrary
+import org.gradle.language.base.artifact.SourcesArtifact
+import org.gradle.language.java.artifact.JavadocArtifact
 
 class AARLinkSourcesPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        project.configurations.create('aarLinkSources')
-        project.configurations.create('aarLinkJavadoc')
 
         if (!project.rootProject.tasks.hasProperty('aarLinkSources')) {
             final AARLinkSourcesTask aarLinkSourcesTask = project.rootProject.tasks.create('aarLinkSources', AARLinkSourcesTask)
 
             project.rootProject.gradle.projectsEvaluated {
-                project.rootProject.allprojects.each {
-                    if (it.configurations.hasProperty('aarLinkSources')) {
-                        it.configurations.aarLinkSources.each { File file ->
-                            aarLinkSourcesTask.linkSources file
-                        }
+                def artifacts = getProjectDependencies(project).findAll { it.type.equals("aar") }
+                        .unique()
 
-                        it.configurations.aarLinkJavadoc.each { File file ->
-                            aarLinkSourcesTask.linkJavadoc file
-                        }
-                    }
+                def identifiers = artifacts.collect {
+                    new DefaultModuleComponentIdentifier(it.moduleVersion.id.group, it.moduleVersion.id.name, it.moduleVersion.id.version)
+                }
+
+                project.dependencies.createArtifactResolutionQuery().forComponents(identifiers)
+                        .withArtifacts(JvmLibrary, SourcesArtifact, JavadocArtifact)
+                        .execute().resolvedComponents.each {
+                    it.getArtifacts(SourcesArtifact).each { aarLinkSourcesTask.linkSources it.file }
+                    it.getArtifacts(JavadocArtifact).each { aarLinkSourcesTask.linkJavadoc it.file }
                 }
 
                 aarLinkSourcesTask.executeWithoutThrowingTaskFailure()
             }
         }
+    }
+
+    private static Collection<ResolvedArtifact> getProjectDependencies(Project project) {
+        return project.rootProject.allprojects.collectMany { it.configurations }
+                .collectMany { it.resolvedConfiguration.resolvedArtifacts }
     }
 }

--- a/plugin/src/main/groovy/com/xujiaao/android/idea/AARLinkSourcesTask.groovy
+++ b/plugin/src/main/groovy/com/xujiaao/android/idea/AARLinkSourcesTask.groovy
@@ -20,17 +20,10 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
 class AARLinkSourcesTask extends DefaultTask {
-    private static final String TAG = 'AARLinkSources'
-
-    boolean debug = false;
 
     // -------------------------------------------------------------------------------------------------------------------------------------
     // Interfaces
     // -------------------------------------------------------------------------------------------------------------------------------------
-
-    void debug(boolean enabled) {
-        debug = enabled
-    }
 
     void linkSources(File file) {
         link file, 'sources'
@@ -60,9 +53,7 @@ class AARLinkSourcesTask extends DefaultTask {
 
                 new XmlNodePrinter(new PrintWriter(new FileWriter(xml))).print(root)
 
-                if (debug) {
-                    println "[${TAG}] [Info] Link success: ${xml.name}"
-                }
+                project.logger.debug("Link success: {}", xml.name)
             }
         }
     }
@@ -77,9 +68,7 @@ class AARLinkSourcesTask extends DefaultTask {
         String name = file.name
 
         if (!processedFiles.contains(name)) {
-            if (debug) {
-                println "[${TAG}] [Info] Link ${type}: ${name}"
-            }
+            project.logger.debug("Link {}: {}", type, name)
 
             processedFiles.add(name)
 
@@ -100,8 +89,8 @@ class AARLinkSourcesTask extends DefaultTask {
                 if (xml.exists() && xml.isFile()) {
                     inputs.property "${xml.name}:${type}".toString(), generatePath(file)
                     outputs.file xml
-                } else if (debug) {
-                    println "[${TAG}] [Error] No such file: ${xml.absolutePath}"
+                } else {
+                    project.logger.debug("No such file: {}", xml.absolutePath)
                 }
             }
         }

--- a/plugin/src/main/groovy/com/xujiaao/android/idea/AARLinkSourcesTask.groovy
+++ b/plugin/src/main/groovy/com/xujiaao/android/idea/AARLinkSourcesTask.groovy
@@ -53,7 +53,8 @@ class AARLinkSourcesTask extends DefaultTask {
                 def path = null;
                 if ((path = inputs.getProperties().get("${xml.name}:sources".toString()))) {
                     appendPath(root.library[0].SOURCES[0], path)
-                } else if ((path = inputs.getProperties().get("${xml.name}:javadoc".toString()))) {
+                }
+                if ((path = inputs.getProperties().get("${xml.name}:javadoc".toString()))) {
                     appendPath(root.library[0].JAVADOC[0], path)
                 }
 

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -32,5 +32,4 @@ apply plugin: 'aar-link-sources'
 
 dependencies {
     compile 'com.android.support:support-v4:20.0.0'
-    aarLinkSources 'com.android.support:support-v4:20.0.0:sources@jar'
 }


### PR DESCRIPTION
Now the plugin iterates over the dependency graph automatically, so manaually declaring the source dependencies is no longer needed (and not possible).
This solution requires Gradle 2.2 or newer to be configured on the project.